### PR TITLE
fix: use UBT to compile source

### DIFF
--- a/make_editor.sh
+++ b/make_editor.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+if [ -z "${UE5_ROOT}" ]; then
+	printf "Please set UE5_ROOT to path of UnrealEngine's root folder\n"
+	exit 1
+fi
+
 PROJECT_NAME="LeoRoverUE5"
 
-make --file="./Makefile" ${PROJECT_NAME}Editor
+${UE5_ROOT}/Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool Development Linux -Project="${PWD}/${PROJECT_NAME}.uproject" -TargetType=Editor


### PR DESCRIPTION
This patch forces the source to be compiled using UBT rather than the make command.